### PR TITLE
Cosmetic change: Don't echo command that was run if no substitutions were performed.

### DIFF
--- a/git-number
+++ b/git-number
@@ -97,16 +97,21 @@ if (scalar @ARGV == 0) {
 }
 
 my @args;
+my $converted=0;
 foreach my $arg (@ARGV) {
     if ( $arg =~ m/^[0-9][0-9]*$/ ) {
         push @args, split("\n", `git-list $arg`);
+        $converted=1;
     } elsif ( $arg =~ m/^[0-9][0-9]*-[0-9][0-9]*$/ ) {
         push @args, split("\n", `git-list $arg`);
+        $converted=1;
     } else {
         push @args, $arg;
     }
 }
 
 my $cmd = "$run " . join(' ', @args);
-print $cmd . "\n";
+if ( $converted ) {
+    print $cmd . "\n";
+}
 system($cmd);


### PR DESCRIPTION
Previously, git-number would always echo the command that it ran, even
if it did not substitute any numbers from the arguments. Now, git-number
will not echo the command that it ran if no number substitutions were
performed.

If a user wanted to pass lots of relevant git commands through
git-number first via shell aliases, then echoing what happened if
nothing happened is a bit bothersome.
