### PR TITLE
Add branch information to short status

### DIFF
--- a/git-id
+++ b/git-id
@@ -47,7 +47,7 @@ if (! $untracked_in_columns) {
     $status_opt .= " --column=never";
 }
 
-my @status_option_for = ( '', '--short' );
+my @status_option_for = ( '', '--short --branch' );
 my $status_format = $status_option_for[$status_style];
 my $git_cmd = "git -c color.status=$color status $status_opt $status_format "
               . join(' ', @ARGV);

--- a/git-list
+++ b/git-list
@@ -105,7 +105,7 @@ sub get_file_list {
                 }
             }
         },
-        '--short' => sub {
+        '--short --branch' => sub {
             while (my $line = <$cache>) {
                 next if $line !~ /^[0-9]+\s/;
                 chomp $line;

--- a/git-number
+++ b/git-number
@@ -43,7 +43,7 @@ All arguments that follows <cmd> will be passed on to <cmd>.
 
 =item -s
 
-Shows I<git status> with the I<--short> option.
+Shows I<git status> with the I<--short --branch> option.
 
 =item -v
 


### PR DESCRIPTION
When running 'git number -s', the branch is now shown. This is the same as running:

```
$ git status --short --branch
```

The only change that has been made here is that the '--branch' option is now passed to git status.

Note that this is simpler than my first pull request a few weeks ago. Less duplicated code and I'm hoping the tests don't need to change. If you can tell me how to run the perl unit tests that you have, I am happy to verify they still work afterwards.

