### PR TITLE
A fix for passing arguments containing spaces

### DIFF
--- a/git-number
+++ b/git-number
@@ -148,7 +148,7 @@ while (scalar @ARGV) {
         push @args, split("\n", `git-list $arg`);
         $converted=1;
     } else {
-        push @args, $arg;
+        push @args, ("\"" . $arg . "\"");
     }
 }
 


### PR DESCRIPTION
Previously, if you did:
    $ gn commit -m "My message"
It would fail. "My message" would be passed to git as two separate arguments. Git would complain about not recognizing "message":
    error: pathspec 'message' did not match any file(s) known to git.

This adds quotations around every argument passed to a normal git command.
