### PR TITLE
A fix for passing arguments with spaces

### DIFF
--- a/git-number
+++ b/git-number
@@ -149,7 +149,7 @@ while (scalar @ARGV) {
         $converted=1;
     } else {
         if (index($arg, ' ') != -1) {
-            $arg = ("\"" . $arg . "\"");
+            $arg = "\"$arg\"";
         }
         push @args, $arg;
     }


### PR DESCRIPTION
Previously, if you did:
    gn commit -m "My message"
It would fail. "My message" would be passed to git as two separate arguments. Git would complain about not recognizing "message":
    error: pathspec 'message' did not match any file(s) known to git.

This adds quotations around those arguments which contain spaces.
