### PR TITLE
Bugfix for filenames containing parentheses

### DIFF
--- a/git-list
+++ b/git-list
@@ -157,7 +157,7 @@ sub get_file_ids {
     my %file_for;
     foreach my $entry (@file_list) {
         my $filename = $entry->{filename};
-        if ($filename =~ / /) {
+        if ($filename =~ /[ ()]/) {
             $filename = '"' . $filename . '"';
         }
         $file_for{$entry->{number}} = $filename;


### PR DESCRIPTION
git-list already adds quotations for filenames containing spaces. It should also use quotations for filenames containing parentheses.

Suppose you do `git-number add 3`, where `3` corresponds to `file(withParens).txt`. git-number will run:
    `git add file(withParens).txt`
Which fails. Parens ought to be escaped or placed inside quotes. This proposed fix changes git-list so that git-number instead runs:
    `git add "file(withParens).txt"`
