### PR TITLE
Use correct hashbang

### DIFF
--- a/git-id
+++ b/git-id
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # vim: sts=4 sw=4 ts=4 expandtab:
 =pod
 

--- a/git-list
+++ b/git-list
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # vim: sts=4 sw=4 ts=4 expandtab:
 # gl - List files from .git/gitids.txt
 

--- a/git-number
+++ b/git-number
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use File::Basename;


### PR DESCRIPTION
All of the other scripts under `t` use the correct `#!/usr/bin/env perl` instead of `#!/usr/bin/perl`. 

This has never been a problem until I tried to use git-number on NixOS, which uses a 
different directory structure, having perl at `/run/current-system/sw/bin/perl`,
and correcting the hashbang fixes the problem. Tested on NixOS, Ubuntu, Kali, and OSX.